### PR TITLE
Remove dead comma-separated parsing for List[str] env settings; fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Behavior:
 
 - `HYPERTRADE_MAX_PAYLOAD_BYTES` (default `65536`): reject requests larger than this size with 413.
 - `HYPERTRADE_ENABLE_TRUSTED_HOSTS` (default `false`): enable Trusted Host middleware.
-- `HYPERTRADE_TRUSTED_HOSTS` (default `*`): comma-separated list of allowed hosts when Trusted Host is enabled.
+- `HYPERTRADE_TRUSTED_HOSTS` (default `*`): allowed hosts when Trusted Host is enabled. Provide as a JSON list, e.g. `'["example.com","api.example.com"]'` (comma-separated values are not supported by the loader — see the note under IP Whitelisting).
 - Webhook requires `Content-Type: application/json` and returns 415 otherwise.
 
 ### Telegram Notifications (optional)

--- a/hypertrade/config.py
+++ b/hypertrade/config.py
@@ -1,6 +1,5 @@
 """Application configuration using Pydantic BaseSettings."""
 
-import json
 from functools import lru_cache
 from typing import List, Optional
 from pydantic import SecretStr, field_validator, model_validator
@@ -47,7 +46,11 @@ class Settings(BaseSettings):
     ip_whitelist_enabled: bool = False
     trust_forwarded_for: bool = True
 
-    # tv_webhook_ips are hardcoded by default, can be overridden in env
+    # List[str] env overrides (tv_webhook_ips, rate_limit_*_paths, trusted_hosts)
+    # MUST be a JSON array, e.g. HYPERTRADE_TV_WEBHOOK_IPS='["1.2.3.4","5.6.7.8"]'.
+    # pydantic-settings' EnvSettingsSource JSON-decodes these before validation;
+    # a comma-separated value raises SettingsError at startup, so do NOT add a
+    # comma-splitting validator expecting it to work for env input.
     tv_webhook_ips: List[str] = [
         "52.89.214.238",
         "34.212.75.30",
@@ -134,28 +137,6 @@ class Settings(BaseSettings):
             raise ValueError("market_order_premium_bps must be at least 1 bps")
         if value > 500:
             raise ValueError("market_order_premium_bps must not exceed 500 bps (5%)")
-        return value
-
-    @field_validator(
-        "tv_webhook_ips",
-        "rate_limit_only_paths",
-        "rate_limit_exclude_paths",
-        "trusted_hosts",
-        mode="before")
-    @classmethod
-    def _parse_path_list(cls, value):
-        if value is None or isinstance(value, list):
-            return value
-        if isinstance(value, str):
-            text = value.strip()
-            if text.startswith("[") and text.endswith("]"):
-                try:
-                    parsed = json.loads(text)
-                    if isinstance(parsed, list):
-                        return [str(x).strip() for x in parsed]
-                except json.JSONDecodeError:
-                    pass
-            return [part.strip() for part in text.split(",") if part.strip()]
         return value
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Problem

The `_parse_path_list` validator in `hypertrade/config.py` claimed to accept comma-separated values for `tv_webhook_ips`, `rate_limit_*_paths` and `trusted_hosts`. But pydantic-settings' `EnvSettingsSource` JSON-decodes these complex `List[str]` fields **before** the `mode="before"` validator runs — so a comma-separated env value raises `SettingsError` at startup and never reaches the validator. Only JSON arrays actually work via env.

This left two documentation bugs pointing at the same underlying behavior:
- `README` correctly said comma-separated is unsupported for the IP whitelist…
- …but **wrongly** documented `HYPERTRADE_TRUSTED_HOSTS` as comma-separated.

## Changes

- **Remove the redundant validator entirely** — pydantic natively decodes JSON env values into `List[str]`. Also removes the now-unused `json` import.
- **Regression guard**: document the JSON-only requirement on the field so nobody re-adds a comma-splitting validator expecting it to work for env input.
- **Fix README**: `HYPERTRADE_TRUSTED_HOSTS` must be a JSON list, consistent with the IP whitelist note.
- Discarded a stale WIP stash that would have switched the webhook IP docs to comma-separated only — that change would have crashed startup.

## Verification

- Empirically confirmed: JSON env works; comma-separated / bare-IP env raises `SettingsError`.
- Confirmed `Settings()` is constructed only once with no args, so removing programmatic JSON-string ergonomics breaks nothing.
- Full test suite: **38 passed**.

## Note / follow-up

Behavior change: `Settings(field='["x"]')` (programmatic JSON string) is no longer accepted — only lists. No callsite uses it. A `test_config.py` asserting JSON-success + comma-separated-`SettingsError` could lock this contract in CI (not included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)