### PR TITLE
fix(webhook): harden IP auth, async execution, and order precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,18 @@ Enable IP whitelisting for the TradingView webhook endpoint and set allowed IPs:
 export HYPERTRADE_IP_WHITELIST_ENABLED=true
 export 'HYPERTRADE_TV_WEBHOOK_IPS=["52.89.214.238","34.212.75.30","54.218.53.128","52.32.178.7"]'
 
-# If behind a proxy, keep this true so X-Forwarded-For is honored
+# Enable ONLY when behind a trusted reverse proxy. Default is false.
 export HYPERTRADE_TRUST_FORWARDED_FOR=true
 ```
+
+> ⚠️ **Security / breaking change:** `HYPERTRADE_TRUST_FORWARDED_FOR` now defaults
+> to **`false`** (previously `true`). `X-Forwarded-For` is client-supplied and
+> therefore spoofable — a request could otherwise claim a whitelisted IP and
+> bypass the whitelist. When enabled, only the **right-most** `X-Forwarded-For`
+> entry (the address added by your immediate trusted proxy) is used; this assumes
+> a single proxy hop. **If you run behind a reverse proxy and rely on the IP
+> whitelist, you must now set `HYPERTRADE_TRUST_FORWARDED_FOR=true` explicitly**,
+> or every request will be seen as coming from the proxy and rejected.
 
 You can apply the whitelist dependency to other routes using `require_ip_whitelisted()` from `hypertrade/security.py`.
 

--- a/hypertrade/config.py
+++ b/hypertrade/config.py
@@ -44,7 +44,9 @@ class Settings(BaseSettings):
             )
             
     ip_whitelist_enabled: bool = False
-    trust_forwarded_for: bool = True
+    # Secure default: do not trust X-Forwarded-For (it is client-spoofable).
+    # Enable only when behind a trusted reverse proxy; see hypertrade/security.py.
+    trust_forwarded_for: bool = False
 
     # List[str] env overrides (tv_webhook_ips, rate_limit_*_paths, trusted_hosts)
     # MUST be a JSON array, e.g. HYPERTRADE_TV_WEBHOOK_IPS='["1.2.3.4","5.6.7.8"]'.

--- a/hypertrade/database.py
+++ b/hypertrade/database.py
@@ -4,8 +4,9 @@ import os
 import sqlite3
 import logging
 from datetime import datetime, timezone
+from decimal import Decimal
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Union
 
 log = logging.getLogger("uvicorn.error")
 
@@ -96,8 +97,8 @@ class OrderDatabase:
         symbol: str,
         side: str,
         signal: str,
-        quantity: float,
-        price: float,
+        quantity: Union[float, Decimal],
+        price: Union[float, Decimal],
         status: str,
         leverage: Optional[int] = None,
         subaccount: Optional[str] = None,
@@ -144,8 +145,11 @@ class OrderDatabase:
                 symbol,
                 side,
                 signal,
-                quantity,
-                price,
+                # quantity/price may arrive as Decimal (exact, exchange-bound);
+                # the columns are REAL and sqlite3 cannot bind Decimal directly,
+                # so coerce here — the DB is history/analytics, not the order itself.
+                float(quantity),
+                float(price),
                 leverage,
                 subaccount,
                 status,

--- a/hypertrade/middleware/rate_limit.py
+++ b/hypertrade/middleware/rate_limit.py
@@ -29,7 +29,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         max_requests: int,
         window_seconds: int,
         burst: int = 0,
-        trust_forwarded_for: bool = True,
+        trust_forwarded_for: bool = False,  # X-Forwarded-For is spoofable; opt in explicitly
         only_paths: Optional[Iterable[str]] = None,
         exclude_paths: Optional[Iterable[str]] = None,
         whitelist_ips: Optional[Iterable[str]] = None,

--- a/hypertrade/routes/webhooks.py
+++ b/hypertrade/routes/webhooks.py
@@ -53,7 +53,10 @@ async def _place_order_with_retry(client: HyperliquidService, order_request: Ord
     """
     for attempt in range(max_retries + 1):
         try:
-            return client.place_order(order_request)
+            # place_order is synchronous and performs blocking network I/O to
+            # Hyperliquid; run it off the event loop so concurrent requests
+            # (and the health check) are not stalled while an order is in flight.
+            return await asyncio.to_thread(client.place_order, order_request)
         except HyperliquidValidationError:
             # Don't retry validation errors - they're permanent
             log.warning("Order validation failed, not retrying: %s", order_request)
@@ -123,14 +126,14 @@ async def hypertrade_webhook(
         })
     
     symbol = payload.currency.base.upper()
-    try:
-        contracts = float(payload.order.contracts)
-        price = float(payload.order.price)    
-    except (TypeError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail="Invalid 'contracts' or 'price' value") from exc
-        
+    # contracts/price are already validated as Decimal by the Pydantic model;
+    # keep them as Decimal so exchange-bound sizing/pricing stays exact (a float
+    # round-trip corrupts precision, e.g. Decimal(0.1_float) != Decimal("0.1")).
+    contracts = payload.order.contracts
+    price = payload.order.price
+
     # Fifth: processing logic here (TODO: would be good to enqueue the job).
-    nominal_quantity = float(contracts * price)
+    nominal_quantity = contracts * price
     
     log.info(
         "Order parameters: direction=%s symbol=%s interval=%s price=%.2f contracts=%s notional_qty=%.2f alert=%s",

--- a/hypertrade/security.py
+++ b/hypertrade/security.py
@@ -11,15 +11,20 @@ def _extract_client_ip(request: Request, trust_forwarded_for: bool) -> Optional[
     """Return best-effort client IP.
 
     If ``trust_forwarded_for`` is true and an ``X-Forwarded-For`` header is present,
-    use its left-most value. Otherwise, fall back to the socket peer address.
+    use its **right-most** value. Otherwise, fall back to the socket peer address.
+
+    Security: each proxy appends the address it observed to the right of
+    ``X-Forwarded-For``, so the left-most entries are supplied by the client and
+    are spoofable. Only the right-most entry — added by our immediate (trusted)
+    proxy — is trustworthy. This assumes a single trusted proxy hop; enable
+    ``trust_forwarded_for`` only when actually behind such a proxy.
     """
     if trust_forwarded_for:
         xff = request.headers.get("x-forwarded-for")
         if xff:
-            # format: client, proxy1, proxy2 ... take left-most
-            first = xff.split(",")[0].strip()
-            if first:
-                return first
+            parts = [part.strip() for part in xff.split(",") if part.strip()]
+            if parts:
+                return parts[-1]
     if request.client:
         return request.client.host
     return None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,76 @@
+"""Security tests: client IP extraction and X-Forwarded-For handling.
+
+The IP whitelist is one of the two webhook authentication methods, so the
+client-IP extraction must not be spoofable via a client-supplied
+``X-Forwarded-For`` header.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+REPO_ROOT = str(pathlib.Path(__file__).resolve().parents[1])
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from hypertrade.security import _extract_client_ip
+
+
+class _FakeClient:
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class _FakeRequest:
+    """Minimal stand-in exposing the attributes _extract_client_ip reads."""
+
+    def __init__(self, *, xff: str | None = None, peer: str | None = "203.0.113.9") -> None:
+        headers: dict[str, str] = {}
+        if xff is not None:
+            headers["x-forwarded-for"] = xff
+        self.headers = headers
+        self.client = _FakeClient(peer) if peer else None
+
+
+def test_xff_uses_rightmost_not_spoofable_leftmost() -> None:
+    """An attacker who prepends a whitelisted IP must not be trusted.
+
+    Each proxy appends the address it observed to the right, so the right-most
+    entry (added by our trusted proxy) is the only non-client-controlled value.
+    """
+    req = _FakeRequest(xff="52.89.214.238, 203.0.113.9")  # spoofed, real
+    assert _extract_client_ip(req, trust_forwarded_for=True) == "203.0.113.9"
+
+
+def test_xff_single_value_returned_when_trusted() -> None:
+    req = _FakeRequest(xff="198.51.100.7", peer="10.0.0.1")
+    assert _extract_client_ip(req, trust_forwarded_for=True) == "198.51.100.7"
+
+
+def test_xff_ignored_when_not_trusted() -> None:
+    req = _FakeRequest(xff="52.89.214.238", peer="203.0.113.9")
+    assert _extract_client_ip(req, trust_forwarded_for=False) == "203.0.113.9"
+
+
+def test_falls_back_to_peer_without_xff() -> None:
+    req = _FakeRequest(xff=None, peer="203.0.113.9")
+    assert _extract_client_ip(req, trust_forwarded_for=True) == "203.0.113.9"
+
+
+def test_returns_none_when_no_peer_and_no_xff() -> None:
+    req = _FakeRequest(xff=None, peer=None)
+    assert _extract_client_ip(req, trust_forwarded_for=True) is None
+
+
+def test_trust_forwarded_for_defaults_to_false(monkeypatch) -> None:
+    """Secure default: do not honor X-Forwarded-For unless explicitly enabled."""
+    from hypertrade.config import Settings
+
+    monkeypatch.setenv("HYPERTRADE_ENVIRONMENT", "test")
+    monkeypatch.setenv("HYPERTRADE_MASTER_ADDR", "0xMASTER")
+    monkeypatch.setenv("HYPERTRADE_API_WALLET_PRIV", "dummy-priv-key")
+    monkeypatch.setenv("HYPERTRADE_WEBHOOK_SECRET", "secret")
+    monkeypatch.delenv("HYPERTRADE_TRUST_FORWARDED_FOR", raising=False)
+
+    assert Settings(_env_file=None).trust_forwarded_for is False

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -14,6 +14,8 @@ import pathlib
 import json
 import copy
 
+from decimal import Decimal
+
 from fastapi.testclient import TestClient
 from unittest.mock import Mock, patch
 
@@ -251,6 +253,72 @@ def test_webhook_ip_whitelist_blocks_forwarded(monkeypatch):
     assert resp.status_code == 403
     body = resp.json()
     assert body["error"]["status"] == 403
+
+
+def test_webhook_preserves_decimal_precision_in_order(monkeypatch):
+    """Order quantity/price must reach the exchange client as exact Decimals.
+
+    The payload model parses contracts/price as Decimal; converting them to
+    float in the handler corrupts precision (Decimal(0.1_float) != Decimal("0.1"))
+    and can mis-size an order or get it rejected by the exchange.
+    """
+    StubHyperliquidService.reset()
+    app = make_app(monkeypatch, secret="secret")
+    client = TestClient(app)
+
+    payload = copy.deepcopy(BASE_PAYLOAD)
+    payload["order"]["contracts"] = "0.1"
+    payload["order"]["price"] = "123456789.123456789"
+
+    resp = client.post("/webhook", json=payload)
+    assert resp.status_code == 200, resp.text
+
+    captured = StubHyperliquidService.last_order_request
+    assert captured is not None
+    assert isinstance(captured.qty, Decimal)
+    assert isinstance(captured.price, Decimal)
+    assert captured.qty == Decimal("0.1")
+    assert captured.price == Decimal("123456789.123456789")
+
+
+async def test_place_order_runs_off_the_event_loop():
+    """The synchronous place_order must not block the event loop.
+
+    place_order blocks on a threading.Event that only a concurrent coroutine can
+    set. If the call ran directly on the loop, that coroutine could never run and
+    the wait would time out — so a passing test proves the call was offloaded.
+    """
+    import asyncio
+    import threading
+
+    from hypertrade.routes.webhooks import _place_order_with_retry
+    from hypertrade.routes.hyperliquid_service import OrderRequest
+    from hypertrade.routes.tradingview_enums import Side, SignalType
+
+    release = threading.Event()
+    placed = {"value": False}
+
+    class BlockingClient:
+        def place_order(self, req):
+            if not release.wait(timeout=2.0):
+                raise AssertionError("event loop blocked: concurrent coroutine never ran")
+            placed["value"] = True
+            return {"orderId": "x"}
+
+    async def concurrent():
+        await asyncio.sleep(0.05)  # can only run if the loop is free
+        release.set()
+
+    req = OrderRequest(
+        symbol="SOL", side=Side.BUY, signal=SignalType.OPEN_LONG, qty=Decimal("1")
+    )
+    result, _ = await asyncio.gather(
+        _place_order_with_retry(BlockingClient(), req),
+        concurrent(),
+    )
+
+    assert placed["value"] is True
+    assert result == {"orderId": "x"}
 
 
 # ===================================================================


### PR DESCRIPTION
Three findings from the code review, each fixed test-first.

## 1. X-Forwarded-For spoofing → IP whitelist bypass (HIGH)
`_extract_client_ip` trusted the **left-most** `X-Forwarded-For` value, which is client-supplied. With the IP whitelist as the sole auth method, an attacker could send `X-Forwarded-For: <whitelisted-ip>` and bypass it.

- Now uses the **right-most** entry (added by the immediate trusted proxy).
- `HYPERTRADE_TRUST_FORWARDED_FOR` now defaults to **`false`** (secure-by-default).
- The shared helper also backs the logging and rate-limit middleware, so all callsites are fixed at once; the rate-limit middleware's own default was aligned to `false` too.

> ⚠️ **Breaking:** deployments behind a reverse proxy that rely on the IP whitelist must now set `HYPERTRADE_TRUST_FORWARDED_FOR=true` explicitly. README updated.

## 2. Event-loop blocking (MEDIUM)
The synchronous, network-bound `place_order` was called directly inside the `async` handler, stalling all concurrent requests (and the health check) while an order was in flight. Now offloaded via `asyncio.to_thread`.

## 3. Decimal precision loss on orders (MEDIUM)
The handler did `float(contracts)` / `float(price)`, corrupting the exact `Decimal` the model and exchange client rely on — `Decimal(0.1_float) != Decimal("0.1")`, and a high-precision price was visibly truncated. Now kept as `Decimal` end-to-end. The order DB has `REAL` columns and sqlite cannot bind `Decimal`, so `log_order` coerces to `float` at that single boundary (history/analytics, not the order sent to the exchange).

## Tests (56 passed)
- `tests/test_security.py` — right-most XFF parsing, spoof rejection, secure default.
- `tests/test_webhook.py` — Decimal preserved into the `OrderRequest`; `place_order` runs off the event loop (deterministic handshake test).

Each fix followed red→green: the test was watched failing against the old behavior before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)